### PR TITLE
Improve like count display in the feed

### DIFF
--- a/socialpy-frontend/src/app/components/home/home.component.css
+++ b/socialpy-frontend/src/app/components/home/home.component.css
@@ -99,6 +99,7 @@
 .like-count {
   padding: var(--feed-content-vert-spacing) var(--feed-content-hor-spacing);
   font-weight: bold;
+  cursor: pointer;
 }
 
 ion-card-content {

--- a/socialpy-frontend/src/app/components/home/home.component.html
+++ b/socialpy-frontend/src/app/components/home/home.component.html
@@ -49,8 +49,14 @@
                                 <fa-icon [icon]="faComment" size="xl"></fa-icon>
                             </div>
                         </div>
-                        <div class="like-count">
-                            {{ feedPost.like_count + (feedPostLikeCounterChange[feedPost.id] || 0) }} likes
+                        <div class="like-count" (click)="openLikersModal(feedPost.id)"
+                            *ngIf="(feedPost.like_count + (feedPostLikeCounterChange[feedPost.id] || 0)) > 0">
+                            <ng-container *ngIf="(feedPost.like_count + (feedPostLikeCounterChange[feedPost.id] || 0)) === 1; else pluralLikes">
+                                {{ feedPost.like_count + (feedPostLikeCounterChange[feedPost.id] || 0) }} like
+                            </ng-container>
+                            <ng-template #pluralLikes>
+                                {{ feedPost.like_count + (feedPostLikeCounterChange[feedPost.id] || 0) }} likes
+                            </ng-template>
                         </div>
                         <ion-card-content>
                             <div class="user-content">


### PR DESCRIPTION
- Modified the like count display to only appear when there's one or more likes.
- Adjusted the wording based on the number of likes: "like" for one like and "likes" for more than one like.
- Incorporated the `feedPostLikeCounterChange` variable to reflect changes in real-time as users like or unlike posts.